### PR TITLE
WINE folder

### DIFF
--- a/layout/mate-applications.menu
+++ b/layout/mate-applications.menu
@@ -17,6 +17,7 @@
 
   <!-- Read in overrides and child menus from applications-merged/ -->
   <DefaultMergeDirs/>
+  <MergeDir>applications-merged</MergeDir>
 
   <!-- Accessories submenu -->
   <Menu>


### PR DESCRIPTION
Hack to show the applications-merged menus in the mate-panel. ie. The WINE folder.
