### PR TITLE
incorrect-fsf-address

### DIFF
--- a/python/matemenu.c
+++ b/python/matemenu.c
@@ -13,8 +13,8 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
  */
 
 #include <config.h>

--- a/util/mate-menus-ls.py
+++ b/util/mate-menus-ls.py
@@ -17,7 +17,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+# MA  02110-1301, USA.
 #
 
 import optparse


### PR DESCRIPTION
before

[rave@mother ~]$ rpmlint /var/lib/mock/fedora-17-x86_64/mate-menus-1.4.0-5.fc17.x86_64.rpm 
mate-menus.x86_64: W: spelling-error %description -l en_US freedesktop -> free desktop, free-desktop, desktop
mate-menus.x86_64: W: private-shared-object-provides /usr/lib64/python2.7/site-packages/matemenu.so matemenu.so()(64bit)
mate-menus.x86_64: W: non-conffile-in-etc /etc/xdg/menus/mate-applications.menu
mate-menus.x86_64: E: incorrect-fsf-address /usr/share/mate-menus/examples/mate-menus-ls.py
mate-menus.x86_64: W: non-conffile-in-etc /etc/xdg/menus/mate-settings.menu
1 packages and 0 specfiles checked; 1 errors, 4 warnings.

after

mate-menus.x86_64: W: spelling-error %description -l en_US freedesktop -> free desktop, free-desktop, desktop
mate-menus.x86_64: W: private-shared-object-provides /usr/lib64/python2.7/site-packages/matemenu.so matemenu.so()(64bit)
mate-menus.x86_64: W: non-conffile-in-etc /etc/xdg/menus/mate-applications.menu
mate-menus.x86_64: W: non-conffile-in-etc /etc/xdg/menus/mate-settings.menu
1 packages and 0 specfiles checked; 0 errors, 4 warnings.

ignore warnings
