### PR TITLE
 add a possibility to enable old gnome-2 preferences menu style with categories

### DIFF
--- a/layout/mate-settings.menu
+++ b/layout/mate-settings.menu
@@ -33,6 +33,7 @@
         </Not>
       </And>
     </Include>
+    <MergeFile>mate-preferences-categories.menu</MergeFile>
   </Menu>
 
   <!-- System Settings -->


### PR DESCRIPTION
BACK to 2008

For get this working the user have to be install /etc/xdg/menus/mate-preferences-categories.menu .
see
https://github.com/NiceandGently/mate-preferences-menus
In result the preferences menu looks like this
https://dl.dropboxusercontent.com/u/49862637/Mate-desktop/SOURCE/preferences-menu.png

Note:
If this file isn't installed on a system than you will see the normal menu.
This change doesn't break anything.
Maybe we can include this file in MATE as an extra package or as an installer option in mate-menus to create a sub package.
