### PR TITLE
Fix bash-izm of '==' operator usage for test(1)

### DIFF
--- a/m4/python.m4
+++ b/m4/python.m4
@@ -34,7 +34,7 @@ AC_MSG_CHECKING(for python libraries)
 dnl Check whether python was compiled as shared library
 link_pymodules_libpython=false;
 py_enable_shared=`$PYTHON -c "from distutils.sysconfig import get_config_var; print repr(get_config_var('Py_ENABLE_SHARED'))"`
-if test $py_enable_shared == 1 ; then
+if test $py_enable_shared = 1 ; then
   if test x`uname -s` != xDarwin; then
       PYTHON_LDFLAGS="-no-undefined"
       link_pymodules_libpython=true;


### PR DESCRIPTION
"==" operator of test(1) is only implemented by bash and some versions
of the ksh.