### PR TITLE
Add missing #include <locale.h>

### DIFF
--- a/util/test-menu-spec.c
+++ b/util/test-menu-spec.c
@@ -19,6 +19,7 @@
 
 #include <config.h>
 #include <glib/gi18n.h>
+#include <locale.h>
 
 #include "matemenu-tree.h"
 


### PR DESCRIPTION
A missing #include <locale.h> was breaking the build inside a snap