### PR TITLE
add Travis-CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,79 @@
+# vim: set ts=2 sts=2 sw=2 expandtab :
+dist: xenial
+sudo: required
+language: bash
+services:
+  - docker
+
+before_install:
+  - curl -Ls -o docker-build https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/docker-build
+  - chmod +x docker-build
+
+install:
+  - sudo apt-get install -y python3-pip python3-setuptools
+  - sudo pip3 install --upgrade pip
+  - sudo pip install PyGithub
+  - ./docker-build --name ${DISTRO} --config .travis.yml --install
+
+script:
+  - ./docker-build --name ${DISTRO} --verbose --config .travis.yml --build autotools
+
+env:
+  - DISTRO="archlinux/base"
+  - DISTRO="debian:sid"
+  - DISTRO="fedora:29"
+  - DISTRO="ubuntu:18.10"
+
+##########################################################
+# THE FOLLOWING LINES IS USED BY docker-build
+##########################################################
+requires:
+  archlinux:
+    # Useful URL: https://git.archlinux.org/svntogit/community.git/tree/mate-menus
+    - gcc
+    - git
+    - glib2
+    - gobject-introspection
+    - intltool
+    - make
+    - mate-common
+    - python2
+    - which
+
+  debian:
+    # Useful URL: https://github.com/mate-desktop/debian-packages
+    # Useful URL: https://salsa.debian.org/debian-mate-team/mate-menus
+    - git
+    - gobject-introspection
+    - intltool
+    - libgirepository1.0-dev
+    - libglib2.0-dev
+    - make
+    - mate-common
+
+  fedora:
+    # Useful URL: https://src.fedoraproject.org/cgit/rpms/mate-menus.git
+    - chrpath
+    - gcc
+    - git
+    - gobject-introspection-devel
+    - make
+    - mate-common
+    - python2-devel
+    - redhat-rpm-config
+
+  ubuntu:
+    - git
+    - gobject-introspection
+    - intltool
+    - libgirepository1.0-dev
+    - libglib2.0-dev
+    - make
+    - mate-common
+
+variables:
+  - CFLAGS="-Wall -Werror=format-security"
+  - PYTHON=python2
+
+after_scripts:
+  - make distcheck


### PR DESCRIPTION
This isn't ready yet.
For some reasons travis build for archlinux failed.
@yetist 
Any idea what is wrong here.
I am still wondering how current mate-menus-1.20.2 is build for Archlinux?