### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.62)
 
-AC_INIT([mate-menus], [1.22.0], [http://www.mate-desktop.org])
+AC_INIT([mate-menus], [1.22.0], [https://mate-desktop.org])
 AC_CONFIG_SRCDIR(libmenu/matemenu-tree.h)
 
 AM_INIT_AUTOMAKE([1.9 foreign no-dist-gzip dist-xz check-news])


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.