### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/libmenu/matemenu-tree.c
+++ b/libmenu/matemenu-tree.c
@@ -842,7 +842,7 @@ matemenu_tree_get_directory_from_path (MateMenuTree  *tree,
  * matemenu_tree_get_entry_by_id:
  * @tree: a #MateMenuTree
  * @id: a desktop file ID
- * 
+ *
  * Look up the entry corresponding to the given "desktop file id".
  *
  * Returns: (transfer full): A newly referenced #MateMenuTreeEntry, or %NULL if none


### PR DESCRIPTION
`find . -regextype posix-extended -regex '.*\.(c|h|ac)' -exec sed --in-place 's/[[:space:]]\+$//' {} \+`

like rbuj do on [https://github.com/mate-desktop/mate-control-center/pull/463](https://github.com/mate-desktop/mate-control-center/pull/463).