### PR TITLE
build: show warning flags on configuration summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,7 @@ echo "
         source code location:         ${srcdir}
         compiler:                     ${CC}
         cflags:                       ${CFLAGS}
+        Warning flags:                ${WARN_CFLAGS}
         Maintainer mode:              ${USE_MAINTAINER_MODE}
         Use *_DISABLE_DEPRECATED:     ${enable_deprecation_flags}
 


### PR DESCRIPTION
```shell
$ ./autogen.sh --enable-compile-warnings=maximum
<cut>

              mate-menus 1.23.0
              =================

        prefix:                       /usr/local
        exec_prefix:                  ${prefix}
        libdir:                       ${exec_prefix}/lib
        bindir:                       ${exec_prefix}/bin
        sbindir:                      ${exec_prefix}/sbin
        sysconfdir:                   ${prefix}/etc
        localstatedir:                ${prefix}/var
        datadir:                      ${datarootdir}
        source code location:         .
        compiler:                     gcc
        cflags:                       -g -O2
        Warning flags:                -Wall -Wmissing-prototypes -Wbad-function-cast -Wcast-align -Wextra -Wformat-nonliteral -Wmissing-declarations -Wmissing-field-initializers -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Wno-sign-compare
        Maintainer mode:              yes
        Use *_DISABLE_DEPRECATED:     no

        Turn on debugging:            minimum
        Build introspection support:  yes


Now type `make' to compile mate-menus
<cut>
```