### PR TITLE
desktop-entries: warning -Wempty-body

### DIFF
--- a/libmenu/desktop-entries.c
+++ b/libmenu/desktop-entries.c
@@ -310,7 +310,9 @@ desktop_entry_load (DesktopEntry *entry)
               g_error_free (error);
             }
           else
-            menu_verbose ("Failed to load \"%s\"\n", entry->path);
+            {
+              menu_verbose ("Failed to load \"%s\"\n", entry->path);
+            }
         }
 
       return retval;


### PR DESCRIPTION
```
desktop-entries.c: In function 'desktop_entry_load':
desktop-entries.c:313:66: warning: suggest braces around empty body in an 'else' statement [-Wempty-body]
  313 |             menu_verbose ("Failed to load \"%s\"\n", entry->path);
      |                                                                  ^
```