### PR TITLE
Remove -Wconversion -Wsign-compare -Wsign-conversion warnings

### DIFF
--- a/libmenu/desktop-entries.c
+++ b/libmenu/desktop-entries.c
@@ -55,13 +55,13 @@ typedef struct
   char     *generic_name;
   char     *comment;
   GIcon    *icon;
-	char* full_name;
-	char* exec;
+  char     *full_name;
+  char     *exec;
 
-  guint     nodisplay   : 1;
-  guint     hidden      : 1;
-  guint     showin      : 1;
-	guint terminal:1;
+  guint     nodisplay : 1;
+  guint     hidden    : 1;
+  guint     showin    : 1;
+  guint     terminal  : 1;
 } DesktopEntryDirectory;
 
 struct DesktopEntrySet {
@@ -236,15 +236,9 @@ desktop_entry_load_directory (DesktopEntry  *entry,
   entry_directory->generic_name = g_key_file_get_locale_string (key_file, DESKTOP_ENTRY_GROUP, "GenericName", NULL, NULL);
   entry_directory->comment      = g_key_file_get_locale_string (key_file, DESKTOP_ENTRY_GROUP, "Comment", NULL, NULL);
   entry_directory->icon         = key_file_get_icon (key_file);
-  entry_directory->nodisplay    = g_key_file_get_boolean (key_file,
-                                                          DESKTOP_ENTRY_GROUP,
-                                                          "NoDisplay",
-                                                          NULL);
-  entry_directory->hidden       = g_key_file_get_boolean (key_file,
-                                                          DESKTOP_ENTRY_GROUP,
-                                                          "Hidden",
-                                                          NULL);
-  entry_directory->showin       = key_file_get_show_in (key_file);
+  entry_directory->nodisplay    = g_key_file_get_boolean (key_file, DESKTOP_ENTRY_GROUP, "NoDisplay", NULL) != FALSE;
+  entry_directory->hidden       = g_key_file_get_boolean (key_file, DESKTOP_ENTRY_GROUP, "Hidden", NULL) != FALSE;
+  entry_directory->showin       = key_file_get_show_in (key_file) != FALSE;
 
   return TRUE;
 }
@@ -435,12 +429,13 @@ DesktopEntry* desktop_entry_copy(DesktopEntry* entry)
     {
       DesktopEntryDesktop *desktop_entry = (DesktopEntryDesktop*) entry;
       DesktopEntryDesktop *retval_desktop_entry = (DesktopEntryDesktop*) retval;
-      int i;
 
       retval_desktop_entry->appinfo = g_object_ref (desktop_entry->appinfo);
 
       if (desktop_entry->categories != NULL)
         {
+          gsize i;
+
           i = 0;
           for (; desktop_entry->categories[i]; i++);
 
@@ -630,7 +625,7 @@ gboolean desktop_entry_has_category(DesktopEntry* entry, const char* category)
 void desktop_entry_add_legacy_category(DesktopEntry* entry)
 {
   GQuark *categories;
-  int     i;
+  gsize   i;
   DesktopEntryDesktop *desktop_entry;
 
   g_return_if_fail (entry->type == DESKTOP_ENTRY_DESKTOP);
@@ -771,7 +766,8 @@ static void desktop_entry_set_clear(DesktopEntrySet* set)
     }
 }
 
-int desktop_entry_set_get_count(DesktopEntrySet* set)
+guint
+desktop_entry_set_get_count (DesktopEntrySet *set)
 {
   if (set->hash == NULL)
     return 0;

--- a/libmenu/desktop-entries.h
+++ b/libmenu/desktop-entries.h
@@ -66,7 +66,7 @@ void desktop_entry_set_unref(DesktopEntrySet* set);
 
 void desktop_entry_set_add_entry(DesktopEntrySet* set, DesktopEntry* entry, const char* file_id);
 DesktopEntry* desktop_entry_set_lookup(DesktopEntrySet* set, const char* file_id);
-int desktop_entry_set_get_count(DesktopEntrySet* set);
+guint desktop_entry_set_get_count (DesktopEntrySet *set);
 
 void desktop_entry_set_union(DesktopEntrySet* set, DesktopEntrySet* with);
 void desktop_entry_set_intersection(DesktopEntrySet* set, DesktopEntrySet* with);

--- a/libmenu/entry-directories.c
+++ b/libmenu/entry-directories.c
@@ -863,7 +863,7 @@ typedef gboolean (*EntryDirectoryForeachFunc) (EntryDirectory* ed, DesktopEntry*
 static gboolean entry_directory_foreach_recursive(EntryDirectory* ed, CachedDir* cd, GString* relative_path, EntryDirectoryForeachFunc func, DesktopEntrySet* set, gpointer user_data)
 {
   GSList *tmp;
-  int     relative_path_len;
+  gsize   relative_path_len;
 
   if (cd->deleted)
     return TRUE;

--- a/libmenu/matemenu-tree.c
+++ b/libmenu/matemenu-tree.c
@@ -109,37 +109,37 @@ struct MateMenuTreeIter
 
 struct MateMenuTreeDirectory
 {
-	MateMenuTreeItem item;
+  MateMenuTreeItem  item;
 
-	DesktopEntry *directory_entry;
-	char         *name;
+  DesktopEntry     *directory_entry;
+  char             *name;
 
-	GSList *entries;
-	GSList *subdirs;
+  GSList           *entries;
+  GSList           *subdirs;
 
-	MenuLayoutValues  default_layout_values;
-	GSList           *default_layout_info;
-	GSList           *layout_info;
-	GSList           *contents;
+  MenuLayoutValues  default_layout_values;
+  GSList           *default_layout_info;
+  GSList           *layout_info;
+  GSList           *contents;
 
-  guint only_unallocated : 1;
-  guint is_nodisplay : 1;
-  guint layout_pending_separator : 1;
-  guint preprocessed : 1;
+  guint             only_unallocated         : 1;
+  guint             is_nodisplay             : 1;
+  guint             layout_pending_separator : 1;
+  guint             preprocessed             : 1;
 
-	/* 16 bits should be more than enough; G_MAXUINT16 means no inline header */
-	guint will_inline_header : 16;
+  /* 16 bits should be more than enough; G_MAXUINT16 means no inline header */
+  guint             will_inline_header       : 16;
 };
 
 struct MateMenuTreeEntry
 {
-  MateMenuTreeItem item;
+  MateMenuTreeItem  item;
 
-  DesktopEntry *desktop_entry;
-  char         *desktop_file_id;
+  DesktopEntry     *desktop_entry;
+  char             *desktop_file_id;
 
-  guint is_excluded : 1;
-  guint is_unallocated : 1;
+  guint             is_excluded    : 1;
+  guint             is_unallocated : 1;
 };
 
 struct MateMenuTreeSeparator
@@ -875,7 +875,7 @@ find_path (MateMenuTreeDirectory *directory,
   slash = strchr (path, G_DIR_SEPARATOR);
   if (slash)
     {
-      name = freeme = g_strndup (path, slash - path);
+      name = freeme = g_strndup (path, (gsize)(slash - path));
       path = slash + 1;
     }
   else
@@ -2529,8 +2529,8 @@ add_menu_for_legacy_dir (MenuLayoutNode *parent,
       GString        *subdir_path;
       GString        *subdir_relative;
       GSList         *tmp;
-      int             legacy_dir_len;
-      int             relative_path_len;
+      size_t          legacy_dir_len;
+      size_t          relative_path_len;
 
       menu = menu_layout_node_new (MENU_LAYOUT_NODE_MENU);
       menu_layout_node_append_child (parent, menu);
@@ -3003,7 +3003,7 @@ find_submenu (MenuLayoutNode *layout,
   slash = strchr (path, G_DIR_SEPARATOR);
   if (slash != NULL)
     {
-      name = g_strndup (path, slash - path);
+      name = g_strndup (path, (gsize)(slash - path));
       next_path = slash + 1;
       if (*next_path == '\0')
         next_path = NULL;
@@ -3425,7 +3425,7 @@ process_include_rules (MenuLayoutNode  *layout,
   if (set == NULL)
     set = desktop_entry_set_new (); /* create an empty set */
 
-  menu_verbose ("Matched %d entries\n", desktop_entry_set_get_count (set));
+  menu_verbose ("Matched %u entries\n", desktop_entry_set_get_count (set));
 
   return set;
 }
@@ -3605,7 +3605,7 @@ process_layout (MateMenuTree          *tree,
              */
             MenuLayoutNode *rule;
 
-	    menu_verbose ("Processing <Include> (%d entries)\n",
+	    menu_verbose ("Processing <Include> (%u entries)\n",
 			  desktop_entry_set_get_count (entries));
 
             rule = menu_layout_node_get_children (layout_iter);
@@ -3626,7 +3626,7 @@ process_layout (MateMenuTree          *tree,
                 rule = menu_layout_node_get_next (rule);
               }
 
-	    menu_verbose ("Processed <Include> (%d entries)\n",
+	    menu_verbose ("Processed <Include> (%u entries)\n",
 			  desktop_entry_set_get_count (entries));
           }
           break;
@@ -3639,7 +3639,7 @@ process_layout (MateMenuTree          *tree,
              */
             MenuLayoutNode *rule;
 
-	    menu_verbose ("Processing <Exclude> (%d entries)\n",
+	    menu_verbose ("Processing <Exclude> (%u entries)\n",
 			  desktop_entry_set_get_count (entries));
 
             rule = menu_layout_node_get_children (layout_iter);
@@ -3659,7 +3659,7 @@ process_layout (MateMenuTree          *tree,
                 rule = menu_layout_node_get_next (rule);
               }
 
-	    menu_verbose ("Processed <Exclude> (%d entries)\n",
+	    menu_verbose ("Processed <Exclude> (%u entries)\n",
 			  desktop_entry_set_get_count (entries));
           }
           break;
@@ -3738,7 +3738,7 @@ process_layout (MateMenuTree          *tree,
 
   desktop_entry_set_unref (entry_pool);
 
-  directory->only_unallocated = only_unallocated;
+  directory->only_unallocated = only_unallocated != FALSE;
 
   if (!directory->only_unallocated)
     desktop_entry_set_union (allocated, allocated_set);
@@ -4105,7 +4105,7 @@ preprocess_layout_info_subdir_helper (MateMenuTree          *tree,
                * higher than that (would be crazy), we just consider it's
                * unlimited */
               if (layout_values->inline_limit < G_MAXUINT16)
-                subdir->will_inline_header = layout_values->inline_limit;
+                subdir->will_inline_header = (guint16) layout_values->inline_limit;
               else
                 subdir->will_inline_header = 0;
             }

--- a/libmenu/menu-layout.c
+++ b/libmenu/menu-layout.c
@@ -998,12 +998,12 @@ menu_layout_values_set (MenuLayoutValues *values,
   if (inline_limit != NULL)
     {
       char *end;
-      int   limit;
+      unsigned long limit;
 
-      limit = strtol (inline_limit, &end, 10);
+      limit = strtoul (inline_limit, &end, 10);
       if (*end == '\0')
 	{
-	  values->inline_limit = limit;
+	  values->inline_limit = (guint) limit;
 	  values->mask |= MENU_LAYOUT_VALUES_INLINE_LIMIT;
 	}
     }
@@ -1142,7 +1142,7 @@ typedef struct
 
 static void set_error (GError             **err,
                        GMarkupParseContext *context,
-                       int                  error_domain,
+                       GQuark               error_domain,
                        int                  error_code,
                        const char          *format,
                        ...) G_GNUC_PRINTF (5, 6);
@@ -1183,7 +1183,7 @@ static GMarkupParser menu_funcs = {
 static void
 set_error (GError              **err,
            GMarkupParseContext  *context,
-           int                   error_domain,
+           GQuark                error_domain,
            int                   error_code,
            const char           *format,
            ...)
@@ -2174,7 +2174,7 @@ end_element_handler (GMarkupParseContext  *context,
 
 static gboolean
 all_whitespace (const char *text,
-                int         text_len)
+                gsize       text_len)
 {
   const char *p;
   const char *end;
@@ -2354,7 +2354,7 @@ menu_layout_load (const char  *filename,
   error = NULL;
   if (!g_markup_parse_context_parse (context,
                                      text,
-                                     length,
+                                     (gssize) length,
                                      &error))
     goto out;
 


### PR DESCRIPTION
```
menu-layout.c:1003:15: warning: conversion from ‘long int’ to ‘int’ may change value [-Wconversion]
 1003 |       limit = strtol (inline_limit, &end, 10);
      |               ^~~~~~
menu-layout.c:1006:27: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
 1006 |    values->inline_limit = limit;
      |                           ^~~~~
--
menu-layout.c:1201:21: warning: conversion to ‘GQuark’ {aka ‘unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
 1201 |   g_set_error (err, error_domain, error_code,
      |                     ^~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
menu-layout.c:2246:34: warning: conversion from ‘gsize’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
 2246 |       if (!all_whitespace (text, text_len))
      |                                  ^~~~~~~~
--
/usr/include/glib-2.0/glib/gmarkup.h:70:24: warning: conversion to ‘int’ from ‘GQuark’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
   70 | #define G_MARKUP_ERROR g_markup_error_quark ()
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
--
menu-layout.c:2357:38: warning: conversion to ‘gssize’ {aka ‘long int’} from ‘gsize’ {aka ‘long unsigned int’} may change the sign of the result [-Wsign-conversion]
 2357 |                                      length,
      |                                      ^~~~~~
--
desktop-entries.c:239:35: warning: conversion from ‘gboolean’ {aka ‘int’} to ‘unsigned char:1’ may change value [-Wconversion]
  239 |   entry_directory->nodisplay    = g_key_file_get_boolean (key_file,
      |                                   ^~~~~~~~~~~~~~~~~~~~~~
desktop-entries.c:243:35: warning: conversion from ‘gboolean’ {aka ‘int’} to ‘unsigned char:1’ may change value [-Wconversion]
  243 |   entry_directory->hidden       = g_key_file_get_boolean (key_file,
      |                                   ^~~~~~~~~~~~~~~~~~~~~~
desktop-entries.c:247:35: warning: conversion from ‘gboolean’ {aka ‘int’} to ‘unsigned char:1’ may change value [-Wconversion]
  247 |   entry_directory->showin       = key_file_get_show_in (key_file);
      |                                   ^~~~~~~~~~~~~~~~~~~~
--
desktop-entries.c:447:64: warning: conversion to ‘gsize’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
  447 |           retval_desktop_entry->categories = g_new0 (GQuark, i + 1);
/usr/include/glib-2.0/glib/gmem.h:261:41: note: in definition of macro ‘_G_NEW’
--
desktop-entries.c:648:38: warning: conversion to ‘gsize’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
  648 |       categories = g_new0 (GQuark, i + 2);
/usr/include/glib-2.0/glib/gmem.h:261:41: note: in definition of macro ‘_G_NEW’
--
desktop-entries.c:779:10: warning: conversion to ‘int’ from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
  779 |   return g_hash_table_size (set->hash);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
matemenu-tree.c:878:46: warning: conversion to ‘gsize’ {aka ‘long unsigned int’} from ‘long int’ may change the sign of the result [-Wsign-conversion]
  878 |       name = freeme = g_strndup (path, slash - path);
      |                                        ~~~~~~^~~~~~
--
matemenu-tree.c:2581:24: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
 2581 |       legacy_dir_len = strlen (legacy_dir);
      |                        ^~~~~~
matemenu-tree.c:2584:27: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
 2584 |       relative_path_len = relative_path ? strlen (relative_path) : 0;
      |                           ^~~~~~~~~~~~~
matemenu-tree.c:2606:47: warning: conversion to ‘gsize’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
 2606 |           g_string_truncate (subdir_relative, relative_path_len);
      |                                               ^~~~~~~~~~~~~~~~~
matemenu-tree.c:2607:43: warning: conversion to ‘gsize’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
 2607 |           g_string_truncate (subdir_path, legacy_dir_len);
      |                                           ^~~~~~~~~~~~~~
--
matemenu-tree.c:3006:37: warning: conversion to ‘gsize’ {aka ‘long unsigned int’} from ‘long int’ may change the sign of the result [-Wsign-conversion]
 3006 |       name = g_strndup (path, slash - path);
      |                               ~~~~~~^~~~~~
--
matemenu-tree.c:3741:33: warning: conversion from ‘gboolean’ {aka ‘int’} to ‘unsigned char:1’ may change value [-Wconversion]
 3741 |   directory->only_unallocated = only_unallocated;
      |                                 ^~~~~~~~~~~~~~~~
--
matemenu-tree.c:4108:46: warning: conversion from ‘guint’ {aka ‘unsigned int’} to ‘short unsigned int’ may change value [-Wconversion]
 4108 |                 subdir->will_inline_header = layout_values->inline_limit;
      |                                              ^~~~~~~~~~~~~
--
entry-directories.c:871:23: warning: conversion from ‘gsize’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
  871 |   relative_path_len = relative_path->len;
      |                       ^~~~~~~~~~~~~
entry-directories.c:894:45: warning: conversion to ‘gsize’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
  894 |           g_string_truncate (relative_path, relative_path_len);
      |                                             ^~~~~~~~~~~~~~~~~
entry-directories.c:919:41: warning: conversion to ‘gsize’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
  919 |       g_string_truncate (relative_path, relative_path_len);
      |                                         ^~~~~~~~~~~~~~~~~
```