### PR TITLE
build: allow users to disable gettext support (--disable-nls)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,8 @@
-SUBDIRS = po libmenu desktop-directories layout util
+if USE_NLS
+PO_SUBDIR = po
+endif
+
+SUBDIRS = $(PO_SUBDIR) libmenu desktop-directories layout util
 
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 

--- a/configure.ac
+++ b/configure.ac
@@ -24,9 +24,9 @@ MATE_COMPILE_WARNINGS
 LIB_MENU_LT_VERSION=6:9:4
 AC_SUBST(LIB_MENU_LT_VERSION)
 
-AM_GNU_GETTEXT_VERSION([0.19.8])
-AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.8])
 AM_GNU_GETTEXT([external])
+AM_GNU_GETTEXT_VERSION([0.19.8])
+AM_CONDITIONAL([USE_NLS], [test "x${USE_NLS}" = "xyes"])
 
 GETTEXT_PACKAGE=mate-menus
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", [Name of default gettext domain])
@@ -102,5 +102,6 @@ echo "
 
         Turn on debugging:            ${enable_debug}
         Build introspection support:  ${found_introspection}
+        Native Language support:      ${USE_NLS}
 
 "

--- a/desktop-directories/Makefile.am
+++ b/desktop-directories/Makefile.am
@@ -30,7 +30,11 @@ directory_in_files = \
 directory_DATA = $(directory_in_files:.directory.in=.directory)
 
 %.directory: %.directory.in
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp $< $@
+endif
 
 EXTRA_DIST= $(directory_in_files)
 

--- a/desktop-directories/Makefile.am
+++ b/desktop-directories/Makefile.am
@@ -38,6 +38,6 @@ endif
 
 EXTRA_DIST= $(directory_in_files)
 
-DISTCLEANFILES = $(directory_DATA)
+CLEANFILES = $(directory_DATA)
 
 -include $(top_srcdir)/git.mk

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -21,3 +21,4 @@ desktop-directories/mate-utility.directory.in
 desktop-directories/mate-menu-applications.directory.in
 desktop-directories/mate-menu-system.directory.in
 desktop-directories/mate-other.directory.in
+util/test-menu-spec.c

--- a/util/test-menu-spec.c
+++ b/util/test-menu-spec.c
@@ -19,7 +19,9 @@
 
 #include <config.h>
 #include <glib/gi18n.h>
+#ifdef ENABLE_NLS
 #include <locale.h>
+#endif
 
 #include "matemenu-tree.h"
 
@@ -202,7 +204,13 @@ main (int argc, char **argv)
 	MateMenuTreeFlags      flags;
 	GError             *error = NULL;
 
+#ifdef ENABLE_NLS
 	setlocale(LC_ALL, "");
+	bindtextdomain (GETTEXT_PACKAGE, MATELOCALEDIR);
+	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+	textdomain (GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
+
 	options_context = g_option_context_new(_("- test MATE's implementation of the Desktop Menu Specification"));
 	g_option_context_add_main_entries(options_context, options, GETTEXT_PACKAGE);
 	g_option_context_parse(options_context, &argc, &argv, NULL);


### PR DESCRIPTION
### With NLS
```
$ find /usr/share/locale -type f -name 'mate-menus.mo' -exec sudo rm -f {} +
$ ./autogen.sh --prefix=/usr && make && sudo make install
$ find /usr/share/locale -type f -name 'mate-menus.mo' -exec du -ch {} + | grep total
552K	total
$ du -h /usr/share/mate/desktop-directories
84K	/usr/share/mate/desktop-directories
```
### Without NLS
```
$ find /usr/share/locale -type f -name 'mate-menus.mo' -exec sudo rm -f {} +
$ ./autogen.sh --prefix=/usr --disable-nls && make && sudo make install
$ find /usr/share/locale -type f -name 'mate-menus.mo' -exec du -ch {} + | grep total
$ du -h /usr/share/mate/desktop-directories
84K	/usr/share/mate/desktop-directories
```
