### PR TITLE
Set compiler debug flags / logging with MATE_DEBUG_CHECK

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,17 +51,18 @@ if test "x$enable_deprecation_flags" = "xyes"; then
    AC_SUBST(DISABLE_DEPRECATED_CFLAGS)
 fi
 
-dnl --enable-debug=(yes/info/profile/no)
-AS_CASE([$ax_enable_debug],
-  [yes|info], [
-    DEBUG_CFLAGS="-DG_ENABLE_DEBUG"
-  ],
-  [no], [
+dnl ---------------------------------------------------------------------------
+dnl - logging
+dnl ---------------------------------------------------------------------------
+if test "$ax_enable_debug" = "yes"; then
+  DEBUG_CFLAGS="-DG_ENABLE_DEBUG"
+else
+  if test "x$ax_enable_debug" = "xno"; then
     DEBUG_CFLAGS="-DG_DISABLE_ASSERT -DG_DISABLE_CHECKS"
-  ],
-  [
+  else
     DEBUG_CFLAGS=""
-  ])
+  fi
+fi
 AC_SUBST(DEBUG_CFLAGS)
 
 GOBJECT_INTROSPECTION_CHECK([0.6.7])
@@ -100,7 +101,7 @@ echo "
         Maintainer mode:              ${USE_MAINTAINER_MODE}
         Use *_DISABLE_DEPRECATED:     ${enable_deprecation_flags}
 
-        Turn on debugging:            ${enable_debug}
+        Turn on debugging:            ${ax_enable_debug}
         Build introspection support:  ${found_introspection}
 
 "


### PR DESCRIPTION
Enable debug / logging:
```
$ ./autogen.sh --prefix=/usr --enable-debug && make V=1 &> make.log && grep DG_ENABLE_DEBUG make.log
<cut>

              mate-menus 1.25.0
              =================

        prefix:                       /usr
        exec_prefix:                  ${prefix}
        libdir:                       ${exec_prefix}/lib64
        bindir:                       ${exec_prefix}/bin
        sbindir:                      ${exec_prefix}/sbin
        sysconfdir:                   /etc
        localstatedir:                /var
        datadir:                      ${datarootdir}
        source code location:         .
        compiler:                     gcc
        cflags:                        -g -O0
        Warning flags:                -Wall -Wmissing-prototypes
        Maintainer mode:              yes
        Use *_DISABLE_DEPRECATED:     no

        Turn on debugging:            yes
        Build introspection support:  yes


Now type `make' to compile mate-menus
```
Disable debug / logging:
```
$ ./autogen.sh --prefix=/usr --disable-debug && make V=1 &> make.log && grep DG_DISABLE_CHECKS make.log
<cut>

              mate-menus 1.25.0
              =================

        prefix:                       /usr
        exec_prefix:                  ${prefix}
        libdir:                       ${exec_prefix}/lib64
        bindir:                       ${exec_prefix}/bin
        sbindir:                      ${exec_prefix}/sbin
        sysconfdir:                   /etc
        localstatedir:                /var
        datadir:                      ${datarootdir}
        source code location:         .
        compiler:                     gcc
        cflags:                       
        Warning flags:                -Wall -Wmissing-prototypes
        Maintainer mode:              yes
        Use *_DISABLE_DEPRECATED:     no

        Turn on debugging:            no
        Build introspection support:  yes


Now type `make' to compile mate-menus
```