### PR TITLE
fix build error: invalid operands to binary expression

### DIFF
--- a/libmenu/matemenu-tree.c
+++ b/libmenu/matemenu-tree.c
@@ -1809,7 +1809,7 @@ gpointer
 matemenu_tree_item_ref (gpointer itemp)
 {
   MateMenuTreeItem* item = (MateMenuTreeItem*) itemp;
-  g_return_val_if_fail(item != NULL || *item != NULL, NULL);
+  g_return_val_if_fail(item != NULL, NULL);
   g_return_val_if_fail(item->refcount > 0, NULL);
 
   g_atomic_int_inc (&item->refcount);


### PR DESCRIPTION
```
CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum --disable-collection && make
```
```
matemenu-tree.c:1812:46: error: invalid operands to binary expression ('MateMenuTreeItem' (aka 'struct MateMenuTreeItem') and 'void *')
  g_return_val_if_fail(item != NULL || *item != NULL, NULL);
                                       ~~~~~ ^  ~~~~
```