### PR TITLE
test-menu-spec: Fix build warning -Wmissing-field-initializers

### DIFF
--- a/util/test-menu-spec.c
+++ b/util/test-menu-spec.c
@@ -39,8 +39,8 @@ static GOptionEntry options[] = {
 	{ "monitor",             'm', 0, G_OPTION_ARG_NONE,   &monitor,             N_("Monitor for menu changes"),       NULL },
 	{ "include-excluded",    'i', 0, G_OPTION_ARG_NONE,   &include_excluded,    N_("Include <Exclude>d entries"),     NULL },
 	{ "include-nodisplay",   'n', 0, G_OPTION_ARG_NONE,   &include_nodisplay,   N_("Include NoDisplay=true entries"), NULL },
-	{ "include-unallocated", 'u', 0, G_OPTION_ARG_NONE,   &include_unallocated, N_("Include unallocated entries"), NULL },
-	{ NULL }
+	{ "include-unallocated", 'u', 0, G_OPTION_ARG_NONE,   &include_unallocated, N_("Include unallocated entries"),    NULL },
+	{ NULL,                    0, 0, G_OPTION_ARG_NONE,   NULL,                 NULL,                                 NULL }
 };
 
 static void


### PR DESCRIPTION
```
test-menu-spec.c:43:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL }
               ^
```