### PR TITLE
fix test programs

### DIFF
--- a/util/mate-menus-ls.py
+++ b/util/mate-menus-ls.py
@@ -68,7 +68,7 @@ def main(args):
         flags |= MateMenu.TreeFlags.INCLUDE_EXCLUDED
     if options.nodisplay:
         flags |= MateMenu.TreeFlags.INCLUDE_NODISPLAY
-    tree = MateMenu.Tree(menu_basename = "mate-applications.menu", flags = flags)
+    tree = MateMenu.Tree(menu_basename = menu_file, flags = flags)
     tree.load_sync();
     root = tree.get_root_directory()
 


### PR DESCRIPTION
Fixed the `--file` argument, you can test with the follow commands:
```
python3 util/mate-menus-ls.py -f mate-applications.menu
python3 util/mate-menus-ls.py -f mate-settings.menu
python3 util/mate-menus-ls.py -f matecc.menu
```