### PR TITLE
libmenu: Use GioUnix-2.0 to introspect the header

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,11 @@ PKG_CHECK_MODULES(GIO_UNIX, gio-unix-2.0 >= 2.50.0)
 AC_SUBST(GIO_UNIX_CFLAGS)
 AC_SUBST(GIO_UNIX_LIBS)
 
+dnl Conditional for GioUnix inclusion in Gir scanning
+PKG_CHECK_MODULES(GIO_UNIX_280, [gio-unix-2.0 >= 2.80.0],
+                  [have_gio_unix_280=yes], [have_gio_unix_280=no])
+AM_CONDITIONAL([HAVE_GIO_UNIX_280], [test "x$have_gio_unix_280" = xyes])
+
 AC_ARG_ENABLE(collection,
   AS_HELP_STRING([--enable-collection],
                  [enable collection menu entry]),,

--- a/libmenu/Makefile.am
+++ b/libmenu/Makefile.am
@@ -58,6 +58,11 @@ introspection_sources = $(libmate_menu_include_HEADERS) matemenu-tree.c
 
 MateMenu-2.0.gir: libmate-menu.la
 MateMenu_2_0_gir_INCLUDES = Gio-2.0
+# Under GIO >= 2.80 we need to include the dependency, see
+# https://gitlab.gnome.org/GNOME/gnome-menus/-/commit/fe1eca74e1b6d75941d56088ea2aeca97b639926
+if HAVE_GIO_UNIX_280
+MateMenu_2_0_gir_INCLUDES += GioUnix-2.0
+endif HAVE_GIO_UNIX_280
 MateMenu_2_0_gir_CFLAGS = $(AM_CPPFLAGS)
 MateMenu_2_0_gir_LIBS = libmate-menu.la
 MateMenu_2_0_gir_SCANNERFLAGS = --identifier-prefix=MateMenu --symbol-prefix=matemenu --pkg-export=libmate-menu --c-include=matemenu-tree.h


### PR DESCRIPTION
This is required since Gio 2.80, see [^1].  We however make the dependency on 2.80 conditional to support older systems as well, as they don't require the modification to work.

Fixes #119 and mate-desktop/mozo#92.

[^1]: https://gitlab.gnome.org/GNOME/gnome-menus/-/commit/fe1eca74e1b6d75941d56088ea2aeca97b639926

---

@raveit65 @willysr @hamkg @mokkurkalve (and others), could you try this PR and see if it works for you?  It's the mentioned patch adjusted not to hard-depend on 2.80 because it looks like some of us don't yet have 2.80 at hand (I don't on my regular machine for the moment) -- and as it's not necessary on those older versions, there's no actual requirement there.