### PR TITLE
libmenu: Use GioUnix-2.0 to introspect the header (meson)

### DIFF
--- a/libmenu/meson.build
+++ b/libmenu/meson.build
@@ -55,7 +55,7 @@ if get_option('introspection')
     export_packages: 'libmatemenu',
     identifier_prefix : 'MateMenu',
     link_with: libmate_menu,
-    includes : ['Gio-2.0'],
+    includes : ['Gio-2.0'] + (gio_unix_280_dep.found() ? ['GioUnix-2.0'] : []),
     install : true,
     install_dir_gir: girdir,
     install_dir_typelib: typelibdir,

--- a/meson.build
+++ b/meson.build
@@ -152,6 +152,10 @@ endif
 gio_req = '>= 2.50.0'
 gio_unix_dep = dependency('gio-unix-2.0', version: gio_req)
 
+# Under GIO >= 2.80 we need to include GioUnix-2.0 in GIR scanning, see
+# https://gitlab.gnome.org/GNOME/gnome-menus/-/commit/fe1eca74e1b6d75941d56088ea2aeca97b639926
+gio_unix_280_dep = dependency('gio-unix-2.0', version: '>= 2.80.0', required: false)
+
 configure_file(
   output: 'config.h',
   configuration: config_h


### PR DESCRIPTION
PR #120 fixed the autotools build to conditionally include GioUnix-2.0 in GIR scanning when gio-unix-2.0 >= 2.80 is present, but the meson build was not updated. Apply the equivalent fix.