### PR TITLE
build: Distribute meson build files when using autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,15 @@ SUBDIRS = $(PO_SUBDIR) libmenu desktop-directories layout util
 
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
-EXTRA_DIST = autogen.sh
+EXTRA_DIST = \
+	autogen.sh \
+	meson.build \
+	meson_options.txt \
+	desktop-directories/meson.build \
+	layout/meson.build \
+	libmenu/meson.build \
+	po/meson.build \
+	util/meson.build
 
 DISTCHECK_CONFIGURE_FLAGS = \
 	--disable-introspection \


### PR DESCRIPTION
This will include missing meson.build files in tarball genereted with autotools.
Tested with `./autogen.sh --enable-gtk-doc --enable-deprecated --disable-strict && make -j5 && make dist -j5 && make distcheck -j5`